### PR TITLE
Update dockerfile to use a newer version of Node

### DIFF
--- a/example1/commander/Dockerfile
+++ b/example1/commander/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12.2
+FROM node:11.9.0
 MAINTAINER Lukasz Guminski <lukasz.guminski@container-solutions.com>
 
 RUN curl -L https://github.com/joeferner/redis-commander/tarball/v0.3.2 | tar zx


### PR DESCRIPTION
When I tried to run example1, it failed in runtime with the following error:
/usr/local/lib/node_modules/redis-commander/bin/redis-commander.js:5
let optimist = require('optimist');
^^^
SyntaxError: Unexpected strict mode reserved word
at exports.runInThisContext (vm.js:73:16)
at Module._compile (module.js:443:25)
at Object.Module._extensions..js (module.js:478:10)
at Module.load (module.js:355:32)
at Function.Module._load (module.js:310:12)
at Function.Module.runMain (module.js:501:10)
at startup (node.js:129:16)
at node.js:814:3

Changing the node version to a newer version like 11.9.0 allowed for the web app to load in the browser.